### PR TITLE
Fix bug that could cause errors with the Forge.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'ghoneycutt-redhat'
-version '0.1.0'
+version '0.1.1'
 source 'git@github.com:ghoneycutt/puppet-module-redhat.git'
 author 'ghoneycutt'
 license 'Apache License, Version 2.0'
@@ -7,4 +7,4 @@ summary 'Manage RedHat systems'
 description 'Manage RedHat (or where osfamily is redhat) specific bits'
 project_page 'https://github.com/ghoneycutt/puppet-module-redhat'
 
-dependency 'puppetlabs/stdlib', '>= 3.2.x'
+dependency 'puppetlabs/stdlib', '3.2.x'


### PR DESCRIPTION
Code was mixing semantic versioning shorthand in the dependency with
greater/less than signs which causes errors on the Forge.
